### PR TITLE
Use fetch from FreeBSD

### DIFF
--- a/install
+++ b/install
@@ -459,6 +459,8 @@ if [ -n "$url" ]; then
       err="$(command curl -fsSLo "$file" -- "$url" 2>&1)"
     elif command -v wget >/dev/null 2>&1; then
       err="$(command wget -O "$file" -- "$url" 2>&1)"
+    elif command -v fetch >/dev/null 2>&1; then
+      err="$(command fetch -q -o "$file" -- "$url" 2>&1)"
     else
       >&2 echo "${_R}error${_0}: please install ${_G}curl${_0} or ${_G}wget${_0} and retry"
       exit 1


### PR DESCRIPTION
- FreeBSD do not come with curl/wget preinstalled so it's difficult to
  bootstrap without installing curl/wget. FreeBSD has a http client in
  it's base which acts in a similar fashion like curl/wget. Utilise
  fetch for easier bootstrap.